### PR TITLE
Update cache and artifact actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Save version 
         run: echo $KLOGG_VERSION > klogg_version.txt
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: klogg_version
           path: 'klogg_version.txt'
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cache openssl
         id: cache-openssl
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}\openssl-1.1
           key: OpensslCache-1-1-1w
@@ -105,7 +105,7 @@ jobs:
           s3-bucket: ${{ secrets.WIN_CS_BUCKET }}
      
 # Final upload of all packages
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: packages-${{ matrix.config.artifacts_id }}
           path: '${{ env.KLOGG_BUILD_ROOT }}/packages/*'


### PR DESCRIPTION
## Summary
- update CI build workflow to use actions/cache@v4
- switch artifact uploads to actions/upload-artifact@v4

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5765a33cc83228700316efe889dda