### PR TITLE
Update cache actions to v4

### DIFF
--- a/.github/actions/agent-setup/action.yml
+++ b/.github/actions/agent-setup/action.yml
@@ -8,7 +8,7 @@ runs:
 
     - name: Cache Qt
       id: cache-qt
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ../Qt
         key: ${{ matrix.config.os }}-${{ matrix.config.arch }}-${{ matrix.config.qt_version }}-QtCache
@@ -30,7 +30,7 @@ runs:
         echo "BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download" >> $GITHUB_ENV
 
     - name: Restore Boost cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}


### PR DESCRIPTION
## Summary
- update the Qt and Boost cache steps in the agent setup action to use actions/cache v4

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5777968188322b7f1dedb097a925b