### PR TITLE
Silence unused parent window warnings in lister plugin

### DIFF
--- a/src/plugins/total_commander_lister/src/lister_plugin.cpp
+++ b/src/plugins/total_commander_lister/src/lister_plugin.cpp
@@ -191,8 +191,9 @@ __declspec( dllexport ) HWND __stdcall ListLoadW( HWND parentWin, const wchar_t*
 }
 
 __declspec( dllexport ) int __stdcall ListLoadNext( HWND parentWin, HWND pluginWin, char* fileToLoad,
-                                                    int showFlags )
+                                                  int showFlags )
 {
+    Q_UNUSED( parentWin );
     return klogg::tc::lister::loadNextFile( pluginWin, klogg::tc::lister::toQString( fileToLoad ),
                                             showFlags );
 }
@@ -200,6 +201,7 @@ __declspec( dllexport ) int __stdcall ListLoadNext( HWND parentWin, HWND pluginW
 __declspec( dllexport ) int __stdcall ListLoadNextW( HWND parentWin, HWND pluginWin, const wchar_t* fileToLoad,
                                                      int showFlags )
 {
+    Q_UNUSED( parentWin );
     return klogg::tc::lister::loadNextFile( pluginWin, klogg::tc::lister::toQString( fileToLoad ),
                                             showFlags );
 }


### PR DESCRIPTION
## Summary
- mark the unused parent window parameter in the ListLoadNext entry points
- avoid MSVC treating these warnings as errors during CI builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58a42ed10832282e73590a8fa41fc