### PR TITLE
Fix Windows release packaging script

### DIFF
--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -71,9 +71,9 @@ xcopy %QTDIR%\bin\%KLOGG_QT%Core5Compat.dll %KLOGG_LISTER_DIR%\ /y
 
 xcopy %QTDIR%\plugins\platforms\qwindows.dll %KLOGG_LISTER_DIR%\platforms\ /y
 xcopy %QTDIR%\plugins\styles\qwindowsvistastyle.dll %KLOGG_LISTER_DIR%\styles\ /y
-xcopy %QTDIR%\plugins\styles\qmodernwindowsstyle.dll %KLOGG_LISTER_DIR%\styles\ /y
+if exist %QTDIR%\plugins\styles\qmodernwindowsstyle.dll xcopy %QTDIR%\plugins\styles\qmodernwindowsstyle.dll %KLOGG_LISTER_DIR%\styles\ /y
 
-xcopy %KLOGG_WORKSPACE%\docs\total_commander_lister.md %KLOGG_LISTER_DIR%\README.md /y
+copy /y "%KLOGG_WORKSPACE%\docs\total_commander_lister.md" "%KLOGG_LISTER_DIR%\README.md" >nul
 xcopy %KLOGG_WORKSPACE%\COPYING %KLOGG_LISTER_DIR%\ /y
 xcopy %KLOGG_WORKSPACE%\NOTICE %KLOGG_LISTER_DIR%\ /y
 
@@ -82,14 +82,14 @@ xcopy %QTDIR%\plugins\platforms\qwindows.dll %KLOGG_WORKSPACE%\release\platforms
 
 md %KLOGG_WORKSPACE%\release\styles
 xcopy %QTDIR%\plugins\styles\qwindowsvistastyle.dll %KLOGG_WORKSPACE%\release\styles /y
-xcopy %QTDIR%\plugins\styles\qmodernwindowsstyle.dll %KLOGG_WORKSPACE%\release\styles /y
+if exist %QTDIR%\plugins\styles\qmodernwindowsstyle.dll xcopy %QTDIR%\plugins\styles\qmodernwindowsstyle.dll %KLOGG_WORKSPACE%\release\styles /y
 
 echo "Copying packaging files..."
-md %KLOGG_WORKSPACE%\chocolately
-xcopy %KLOGG_WORKSPACE%\packaging\windows\klogg.nuspec chocolately /y
+md %KLOGG_WORKSPACE%\chocolatey
+xcopy %KLOGG_WORKSPACE%\packaging\windows\chocolatey\klogg.nuspec %KLOGG_WORKSPACE%\chocolatey\ /y
 
-md %KLOGG_WORKSPACE%\chocolately\tools
-xcopy %KLOGG_WORKSPACE%\packaging\windows\chocolatelyInstall.ps1 chocolately\tools\ /y
+md %KLOGG_WORKSPACE%\chocolatey\tools
+xcopy %KLOGG_WORKSPACE%\packaging\windows\chocolatey\tools\chocolateyInstall.ps1 %KLOGG_WORKSPACE%\chocolatey\tools\ /y
 
 xcopy %KLOGG_WORKSPACE%\packaging\windows\klogg.nsi  /y
 xcopy %KLOGG_WORKSPACE%\packaging\windows\FileAssociation.nsh  /y

--- a/src/plugins/total_commander_lister/src/lister_plugin.cpp
+++ b/src/plugins/total_commander_lister/src/lister_plugin.cpp
@@ -191,8 +191,9 @@ __declspec( dllexport ) HWND __stdcall ListLoadW( HWND parentWin, const wchar_t*
 }
 
 __declspec( dllexport ) int __stdcall ListLoadNext( HWND parentWin, HWND pluginWin, char* fileToLoad,
-                                                    int showFlags )
+                                                  int showFlags )
 {
+    Q_UNUSED( parentWin );
     return klogg::tc::lister::loadNextFile( pluginWin, klogg::tc::lister::toQString( fileToLoad ),
                                             showFlags );
 }
@@ -200,6 +201,7 @@ __declspec( dllexport ) int __stdcall ListLoadNext( HWND parentWin, HWND pluginW
 __declspec( dllexport ) int __stdcall ListLoadNextW( HWND parentWin, HWND pluginWin, const wchar_t* fileToLoad,
                                                      int showFlags )
 {
+    Q_UNUSED( parentWin );
     return klogg::tc::lister::loadNextFile( pluginWin, klogg::tc::lister::toQString( fileToLoad ),
                                             showFlags );
 }


### PR DESCRIPTION
## Summary
- stop the release packaging script from aborting when optional Qt style DLL is missing
- copy the lister documentation into README.md without prompting for target type
- fix Chocolatey packaging paths so the nuspec and install script get staged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58a42ed10832282e73590a8fa41fc