### PR TITLE
Limit CodeQL workflow triggers

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,8 +9,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
-  schedule:
-    - cron: '0 22 * * 4'
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- remove the scheduled trigger from the CodeQL analysis workflow so it no longer runs automatically
- restrict the CodeQL workflow to pull_request events that need analysis while keeping manual dispatch support

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d61d65a7688322903f57d20f24aea1