### PR TITLE
Fix plugin release secret guard and limit CI build merges

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,7 @@ name: "CI Build"
 on:
   pull_request:
     branches: [ master ]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'website/**'
       - BUILD.md

--- a/.github/workflows/totalcmd-plugin-release.yml
+++ b/.github/workflows/totalcmd-plugin-release.yml
@@ -14,6 +14,8 @@ jobs:
   windows-plugin:
     if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: windows-2022
+    env:
+      KLOGG_GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
     strategy:
       matrix:
         config:
@@ -24,6 +26,8 @@ jobs:
             ssl_arch: -x64
             cmake_opts: ''
     steps:
+      # This job performs a fresh checkout, build, test, and packaging sequence,
+      # so it does not require artifacts produced by the ci-build workflow.
       - uses: actions/checkout@v3
 
       - name: Cache OpenSSL
@@ -170,10 +174,10 @@ jobs:
           if-no-files-found: error
 
       - name: Publish plugin release
-        if: ${{ secrets.KLOGG_GITHUB_TOKEN != '' }}
+        if: ${{ env.KLOGG_GITHUB_TOKEN != '' }}
         uses: marvinpinto/action-automatic-releases@latest
         with:
-          repo_token: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+          repo_token: ${{ env.KLOGG_GITHUB_TOKEN }}
           automatic_release_tag: continuous-totalcmd
           prerelease: true
           files: |


### PR DESCRIPTION
## Summary
- expose the Total Commander release workflow's GitHub token secret through the job environment and gate the publish step on it
- ensure the release action receives the token via the environment to avoid the invalid secrets expression
- restrict the CI build workflow to PR events that aren't triggered by merges
- document that the Total Commander plugin release job performs a full build, so it doesn't rely on artifacts from ci-build

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d621e4d8048322887b26730a75b4dc