### PR TITLE
Fix Total Commander plugin packaging to produce self-install zip

### DIFF
--- a/docs/total_commander_lister.md
+++ b/docs/total_commander_lister.md
@@ -74,11 +74,12 @@ is produced during regular Windows CI runs.
 ## Packaging
 
 `packaging/windows/prepare_release.cmd` now stages the plugin under
-`release/totalcmd/plugins/wlx/klogg_lister` and gathers the required Qt runtime
-modules (`QtCore`, `QtGui`, `QtWidgets`, `QtConcurrent`, `QtNetwork`, `QtXml`,
+`release/totalcmd/klogg_lister` and gathers the required Qt runtime modules
+(`QtCore`, `QtGui`, `QtWidgets`, `QtConcurrent`, `QtNetwork`, `QtXml`,
 `Qt5Compat`, plus the `platforms` and `styles` plugins). The script also copies
-`docs/total_commander_lister.md` as `README.md` inside the plugin bundle and
-produces an archive named:
+`docs/total_commander_lister.md` as `README.md` inside the plugin bundle,
+writes a `pluginst.inf` manifest so that Total Commander recognises the ZIP as
+a self-installing lister plugin, and produces an archive named:
 
 ```
 klogg-totalcmd-lister-<version>-<arch>-<qt>.zip

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -63,10 +63,9 @@ xcopy %QTDIR%\bin\%KLOGG_QT%Xml.dll %KLOGG_WORKSPACE%\release\ /y
 xcopy %QTDIR%\bin\%KLOGG_QT%Core5Compat.dll %KLOGG_WORKSPACE%\release\ /y
 
 echo "Staging Total Commander lister plugin runtime..."
-set "KLOGG_LISTER_DIR=%KLOGG_WORKSPACE%\release\totalcmd\plugins\wlx\klogg_lister"
-md %KLOGG_WORKSPACE%\release\totalcmd
-md %KLOGG_WORKSPACE%\release\totalcmd\plugins
-md %KLOGG_WORKSPACE%\release\totalcmd\plugins\wlx
+set "KLOGG_LISTER_ROOT=%KLOGG_WORKSPACE%\release\totalcmd"
+set "KLOGG_LISTER_DIR=%KLOGG_LISTER_ROOT%\klogg_lister"
+md %KLOGG_LISTER_ROOT%
 md %KLOGG_LISTER_DIR%
 md %KLOGG_LISTER_DIR%\platforms
 md %KLOGG_LISTER_DIR%\styles
@@ -88,7 +87,7 @@ if exist %QTDIR%\plugins\styles\qwindowsvistastyle.dll (
     echo "Warning: %QTDIR%\plugins\styles\qwindowsvistastyle.dll not found for lister plugin"
 )
 if exist %QTDIR%\plugins\styles\qmodernwindowsstyle.dll (
-    xcopy %QTDIR%\plugins\styles\qmodernwindowsstyle.dll %KLOGG_LISTER_DIR%\styles\ /y
+xcopy %QTDIR%\plugins\styles\qmodernwindowsstyle.dll %KLOGG_LISTER_DIR%\styles\ /y
 ) else (
     echo "Warning: %QTDIR%\plugins\styles\qmodernwindowsstyle.dll not found for lister plugin"
 )
@@ -96,6 +95,9 @@ if exist %QTDIR%\plugins\styles\qmodernwindowsstyle.dll (
 copy /y "%KLOGG_WORKSPACE%\docs\total_commander_lister.md" "%KLOGG_LISTER_DIR%\README.md" >nul
 xcopy %KLOGG_WORKSPACE%\COPYING %KLOGG_LISTER_DIR%\ /y
 xcopy %KLOGG_WORKSPACE%\NOTICE %KLOGG_LISTER_DIR%\ /y
+
+copy /y "%KLOGG_WORKSPACE%\packaging\windows\totalcmd\pluginst.inf.in" "%KLOGG_LISTER_ROOT%\pluginst.inf" >nul
+powershell -NoProfile -Command "(Get-Content '%KLOGG_LISTER_ROOT%\pluginst.inf') -replace '@KLOGG_VERSION@', $env:KLOGG_VERSION | Set-Content '%KLOGG_LISTER_ROOT%\pluginst.inf' -Encoding ASCII"
 
 md %KLOGG_WORKSPACE%\release\platforms
 xcopy %QTDIR%\plugins\platforms\qwindows.dll %KLOGG_WORKSPACE%\release\platforms\ /y
@@ -128,6 +130,8 @@ set "TBB_PDB_ARGS="
 if exist %KLOGG_WORKSPACE%\release\tbb12.dll set "TBB_PDB_ARGS=%TBB_PDB_ARGS% .\release\tbb12.dll"
 if exist %KLOGG_WORKSPACE%\release\tbb12.pdb set "TBB_PDB_ARGS=%TBB_PDB_ARGS% .\release\tbb12.pdb"
 7z a %KLOGG_WORKSPACE%\klogg-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%-pdb.zip .\release\klogg.exe .\release\klogg.pdb .\release\klogg_portable.exe .\release\klogg_portable.pdb%TBB_PDB_ARGS%
-7z a -r %KLOGG_WORKSPACE%\klogg-totalcmd-lister-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%.zip %KLOGG_LISTER_DIR%\*
+pushd %KLOGG_LISTER_ROOT%
+7z a -r %KLOGG_WORKSPACE%\klogg-totalcmd-lister-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%.zip *
+popd
 
 echo "Done!"

--- a/packaging/windows/totalcmd/pluginst.inf.in
+++ b/packaging/windows/totalcmd/pluginst.inf.in
@@ -1,0 +1,6 @@
+[plugininstall]
+title=Klogg Lister Plugin
+description=Embed the Klogg log viewer inside Total Commander.
+type=wlx
+version=@KLOGG_VERSION@
+defaultdir=klogg_lister


### PR DESCRIPTION
## Summary
- stage the lister plugin under release/totalcmd and add a pluginst.inf manifest so Total Commander recognises the archive as self-installing
- generate pluginst.inf from a template that records the build version and package the ZIP from the staging root
- document the new packaging layout for the Total Commander integration guide

## Testing
- no automated tests were run (Windows packaging script only)


------
https://chatgpt.com/codex/tasks/task_e_68d69e204338832280b2ad74bc56d355