### PR TITLE
Fix Total Commander plugin packaging and release publishing

### DIFF
--- a/.github/workflows/totalcmd-plugin-release.yml
+++ b/.github/workflows/totalcmd-plugin-release.yml
@@ -12,10 +12,10 @@ on:
 
 jobs:
   windows-plugin:
+    permissions:
+      contents: write
     if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: windows-2022
-    env:
-      KLOGG_GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
     strategy:
       matrix:
         config:
@@ -174,10 +174,9 @@ jobs:
           if-no-files-found: error
 
       - name: Publish plugin release
-        if: ${{ env.KLOGG_GITHUB_TOKEN != '' }}
         uses: marvinpinto/action-automatic-releases@latest
         with:
-          repo_token: ${{ env.KLOGG_GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: continuous-totalcmd
           prerelease: true
           files: |

--- a/docs/total_commander_lister.md
+++ b/docs/total_commander_lister.md
@@ -77,15 +77,19 @@ is produced during regular Windows CI runs.
 `release/totalcmd/plugins/wlx/klogg_lister` and gathers the required Qt runtime
 modules (`QtCore`, `QtGui`, `QtWidgets`, `QtConcurrent`, `QtNetwork`, `QtXml`,
 `Qt5Compat`, plus the `platforms` and `styles` plugins). The script also copies
-`docs/total_commander_lister.md` as `README.md` inside the plugin bundle and
-produces an archive named:
+`docs/total_commander_lister.md` as `README.md` inside the plugin bundle,
+writes a `pluginst.inf` manifest at the root of the bundle so Total Commander
+recognises the ZIP as an auto-install package, and produces an archive named:
 
 ```
 klogg-totalcmd-lister-<version>-<arch>-<qt>.zip
 ```
 
-Distribute this ZIP directly into Total Commander’s configuration directory
-(e.g. extract to `%COMMANDER_PATH%\plugins\wlx\klogg_lister`).
+Total Commander users can install the ZIP directly (press `Enter` on the
+archive inside Total Commander) or extract it manually into
+`%COMMANDER_PATH%\plugins\wlx\klogg_lister`. The CI workflow uploads this
+archive as a release asset so it appears on the GitHub **Releases** page in
+addition to the workflow artifacts.
 
 ## Installation & usage
 

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -97,6 +97,16 @@ copy /y "%KLOGG_WORKSPACE%\docs\total_commander_lister.md" "%KLOGG_LISTER_DIR%\R
 xcopy %KLOGG_WORKSPACE%\COPYING %KLOGG_LISTER_DIR%\ /y
 xcopy %KLOGG_WORKSPACE%\NOTICE %KLOGG_LISTER_DIR%\ /y
 
+echo "Writing Total Commander auto-install manifest..."
+set "KLOGG_TOTALCMD_ROOT=%KLOGG_WORKSPACE%\release\totalcmd"
+for %%F in ("%KLOGG_TOTALCMD_ROOT%\pluginst.inf") do del "%%~fF" 2>nul
+powershell -NoLogo -NoProfile -Command ^
+  "$pluginRoot = Join-Path $env:KLOGG_WORKSPACE 'release/totalcmd';" ^
+  "$pluginDir = 'plugins\\wlx\\klogg_lister';" ^
+  "$files = Get-ChildItem -Path (Join-Path $pluginRoot $pluginDir) -File -Recurse | ForEach-Object { $_.FullName.Substring($pluginRoot.Length + 1) };" ^
+  "$header = @('[plugininstall]', 'type=wlx', 'description=Klogg Lister Plugin ' + $env:KLOGG_VERSION + ' (' + $env:KLOGG_ARCH + ')', 'targetdir=%COMMANDER_PATH%\\plugins\\wlx\\klogg_lister', '', '[source]');" ^
+  "Set-Content -Path (Join-Path $pluginRoot 'pluginst.inf') -Value ($header + $files) -Encoding Ascii"
+
 md %KLOGG_WORKSPACE%\release\platforms
 xcopy %QTDIR%\plugins\platforms\qwindows.dll %KLOGG_WORKSPACE%\release\platforms\ /y
 
@@ -128,6 +138,8 @@ set "TBB_PDB_ARGS="
 if exist %KLOGG_WORKSPACE%\release\tbb12.dll set "TBB_PDB_ARGS=%TBB_PDB_ARGS% .\release\tbb12.dll"
 if exist %KLOGG_WORKSPACE%\release\tbb12.pdb set "TBB_PDB_ARGS=%TBB_PDB_ARGS% .\release\tbb12.pdb"
 7z a %KLOGG_WORKSPACE%\klogg-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%-pdb.zip .\release\klogg.exe .\release\klogg.pdb .\release\klogg_portable.exe .\release\klogg_portable.pdb%TBB_PDB_ARGS%
-7z a -r %KLOGG_WORKSPACE%\klogg-totalcmd-lister-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%.zip %KLOGG_LISTER_DIR%\*
+pushd "%KLOGG_TOTALCMD_ROOT%"
+7z a -tzip %KLOGG_WORKSPACE%\klogg-totalcmd-lister-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%.zip *
+popd
 
 echo "Done!"


### PR DESCRIPTION
## Summary
- ensure the Total Commander plugin ZIP is built from the staged bundle root so the manifest sits alongside the files instead of ending up inside another archive
- update the lister plugin documentation to mention the manifest placement and that the CI release attaches the auto-install ZIP
- grant the workflow permissions required to publish releases and use the default GitHub token so every run updates the `continuous-totalcmd` release asset

## Testing
- not run (workflow and packaging script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6a7d799d083229156a04367b0ab78