### PR TITLE
Fix Total Commander plugin packaging

### DIFF
--- a/.github/workflows/totalcmd-plugin-release.yml
+++ b/.github/workflows/totalcmd-plugin-release.yml
@@ -180,7 +180,19 @@ jobs:
 
           $out = Join-Path $env:KLOGG_WORKSPACE ("klogg-totalcmd-lister-" + $env:KLOGG_VERSION + "-" + $env:KLOGG_ARCH + "-" + $env:KLOGG_QT + ".zip")
           Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue
-          Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $out -Force
+
+          $pluginManifest = Join-Path $stage 'pluginst.inf'
+          if (-not (Test-Path -LiteralPath $pluginManifest)) {
+            throw "pluginst.inf manifest not found at $pluginManifest"
+          }
+
+          Push-Location $stage
+          try {
+            Compress-Archive -Path * -DestinationPath $out -Force
+          }
+          finally {
+            Pop-Location
+          }
 
           Add-Type -AssemblyName System.IO.Compression.FileSystem
           $zip = [IO.Compression.ZipFile]::OpenRead($out)


### PR DESCRIPTION
## Summary
- fail early if the Total Commander plugin manifest is missing before packaging
- create the plugin ZIP from inside the staging directory to keep pluginst.inf at the archive root

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d78f65deb88322a90cd3addef8e2f0