### PR TITLE
Ensure Total Commander plugin manifest is generated

### DIFF
--- a/.github/workflows/totalcmd-plugin-release.yml
+++ b/.github/workflows/totalcmd-plugin-release.yml
@@ -178,6 +178,20 @@ jobs:
             throw "Total Commander stage '$stage' not found"
           }
 
+          $manifestScript = Join-Path $env:KLOGG_WORKSPACE 'packaging/windows/write_plugin_manifest.ps1'
+          if (-not (Test-Path -LiteralPath $manifestScript)) {
+            throw "Manifest helper script not found at $manifestScript"
+          }
+
+          $pluginFile = 'klogg_lister.wlx'
+          $pluginType = 'wlx'
+          if ($env:KLOGG_ARCH -and ($env:KLOGG_ARCH -match '64')) {
+            $pluginFile = 'klogg_lister.wlx64'
+            $pluginType = 'wlx64'
+          }
+
+          & $manifestScript -PluginRoot $stage -Version $env:KLOGG_VERSION -PluginFile $pluginFile -PluginType $pluginType
+
           $out = Join-Path $env:KLOGG_WORKSPACE ("klogg-totalcmd-lister-" + $env:KLOGG_VERSION + "-" + $env:KLOGG_ARCH + "-" + $env:KLOGG_QT + ".zip")
           Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue
 

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -103,22 +103,11 @@ xcopy %KLOGG_WORKSPACE%\NOTICE %KLOGG_TOTALCMD_ROOT%\ /y
 
 echo "Writing Total Commander auto-install manifest..."
 for %%F in ("%KLOGG_TOTALCMD_ROOT%\pluginst.inf") do del "%%~fF" 2>nul
-powershell -NoLogo -NoProfile -Command ^
-  "Set-StrictMode -Version Latest;" ^
-  "$pluginRoot = Join-Path $env:KLOGG_WORKSPACE 'release/totalcmd';" ^
-  "$pluginFile = $env:KLOGG_TOTALCMD_PLUGIN_FILE;" ^
-  "$pluginType = $env:KLOGG_TOTALCMD_PLUGIN_TYPE;" ^
-  "$lines = @(
-    '[plugininstall]',
-    'version=' + $env:KLOGG_VERSION,
-    'defaultdir=klogg_lister',
-    'type=' + $pluginType,
-    'file=' + $pluginFile,
-    'name=Klogg Log Viewer',
-    'description=Log viewer plugin for Total Commander',
-    'defaultextension=LOG LOGX LOGS CEF CLF ELF W3C OUT ERR'
-  );" ^
-  "Set-Content -Path (Join-Path $pluginRoot 'pluginst.inf') -Value $lines -Encoding Ascii"
+powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%KLOGG_WORKSPACE%\packaging\windows\write_plugin_manifest.ps1" ^
+  -PluginRoot "%KLOGG_TOTALCMD_ROOT%" ^
+  -PluginFile "%KLOGG_TOTALCMD_PLUGIN_FILE%" ^
+  -PluginType "%KLOGG_TOTALCMD_PLUGIN_TYPE%" ^
+  -Version "%KLOGG_VERSION%"
 
 md %KLOGG_WORKSPACE%\release\platforms
 xcopy %QTDIR%\plugins\platforms\qwindows.dll %KLOGG_WORKSPACE%\release\platforms\ /y

--- a/packaging/windows/write_plugin_manifest.ps1
+++ b/packaging/windows/write_plugin_manifest.ps1
@@ -1,0 +1,57 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$PluginRoot = $(if ($env:KLOGG_WORKSPACE) { Join-Path $env:KLOGG_WORKSPACE 'release/totalcmd' } else { '' }),
+
+    [Parameter()]
+    [string]$Version = $env:KLOGG_VERSION,
+
+    [Parameter()]
+    [string]$PluginFile,
+
+    [Parameter()]
+    [string]$PluginType
+)
+
+Set-StrictMode -Version Latest
+
+if (-not $PluginRoot) {
+    throw 'PluginRoot must be provided either via parameter or KLOGG_WORKSPACE environment variable.'
+}
+
+if (-not (Test-Path -LiteralPath $PluginRoot)) {
+    throw "Plugin root '$PluginRoot' does not exist."
+}
+
+$arch = $env:KLOGG_ARCH
+$defaultIs64 = $false
+if ($arch -and ($arch -match '64')) {
+    $defaultIs64 = $true
+}
+
+if (-not $PluginFile) {
+    $PluginFile = if ($defaultIs64) { 'klogg_lister.wlx64' } else { 'klogg_lister.wlx' }
+}
+
+if (-not $PluginType) {
+    $PluginType = if ($defaultIs64) { 'wlx64' } else { 'wlx' }
+}
+
+if (-not $Version) {
+    $Version = '0.0.0'
+}
+
+$manifestPath = Join-Path $PluginRoot 'pluginst.inf'
+
+$lines = @(
+    '[plugininstall]',
+    'version=' + $Version,
+    'defaultdir=klogg_lister',
+    'type=' + $PluginType,
+    'file=' + $PluginFile,
+    'name=Klogg Log Viewer',
+    'description=Log viewer plugin for Total Commander',
+    'defaultextension=LOG LOGX LOGS CEF CLF ELF W3C OUT ERR'
+)
+
+Set-Content -Path $manifestPath -Value $lines -Encoding Ascii -Force


### PR DESCRIPTION
## Summary
- add a reusable PowerShell helper to write the Total Commander plugin manifest
- invoke the helper from the release packaging script instead of inline PowerShell
- regenerate the manifest during the GitHub Actions packaging step before creating the ZIP

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d87f1d2748832285d715a4298d5588