### PR TITLE
Normalize plugin manifest metadata values

### DIFF
--- a/packaging/windows/write_plugin_manifest.ps1
+++ b/packaging/windows/write_plugin_manifest.ps1
@@ -41,6 +41,10 @@ if (-not $Version) {
     $Version = '0.0.0'
 }
 
+$PluginFile = $PluginFile.Trim()
+$PluginType = $PluginType.Trim()
+$Version = $Version.Trim()
+
 $manifestPath = Join-Path $PluginRoot 'pluginst.inf'
 
 $lines = @(


### PR DESCRIPTION
## Summary
- trim plugin manifest metadata values before writing pluginst.inf to avoid embedded newlines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94c2417cc8322b767cfa74d4c84dc