### PR TITLE
Ensure plugin manifest uses LF line endings

### DIFF
--- a/packaging/windows/write_plugin_manifest.ps1
+++ b/packaging/windows/write_plugin_manifest.ps1
@@ -58,4 +58,9 @@ $lines = @(
     'defaultextension=LOG LOGX LOGS CEF CLF ELF W3C OUT ERR'
 )
 
-Set-Content -Path $manifestPath -Value $lines -Encoding Ascii -Force
+$content = ($lines -join "`n") + "`n"
+[System.IO.File]::WriteAllText(
+    $manifestPath,
+    $content,
+    [System.Text.Encoding]::ASCII
+)


### PR DESCRIPTION
## Summary
- update the Total Commander plugin manifest writer to assemble content manually
- write the manifest using ASCII encoding with explicit LF newlines to avoid CRLF splitting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9bbbb128883228eb376f8faa8f513