### PR TITLE
Bundle runtime dependencies with Total Commander plugin

### DIFF
--- a/docs/total_commander_lister.md
+++ b/docs/total_commander_lister.md
@@ -76,10 +76,11 @@ is produced during regular Windows CI runs.
 `packaging/windows/prepare_release.cmd` stages the plugin payload and gathers
 the required Qt runtime modules (`QtCore`, `QtGui`, `QtWidgets`,
 `QtConcurrent`, `QtNetwork`, `QtXml`, `Qt5Compat`, plus the `platforms` and
-`styles` plugins). The script copies `klogg_lister.dll` to
+`styles` plugins) together with the MSVC runtime, OpenSSL libraries, and the
+`tbb12` runtime when present. The script copies `klogg_lister.dll` to
 `release/totalcmd/klogg_lister.wlx64` (WLX/WLX64 files are plain DLLs; the 64-bit
 build uses the `.wlx64` suffix expected by Total Commander) and places the
-Qt runtime files alongside it so the plugin can load without additional
+runtime files alongside it so the plugin can load without additional
 installer steps. `docs/total_commander_lister.md` is copied as `README.md`
 into the same directory. A `pluginst.inf` manifest declares the plugin version,
 default directory, plugin type, staged WLX/WLX64 file, and default extensions

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -77,6 +77,15 @@ if not "%KLOGG_ARCH:64=%"=="%KLOGG_ARCH%" (
 
 copy /y "%KLOGG_WORKSPACE%\%KLOGG_BUILD_ROOT%\output\klogg_lister.dll" "%KLOGG_TOTALCMD_ROOT%\%KLOGG_TOTALCMD_PLUGIN_FILE%" >nul
 
+xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\msvcp140.dll" %KLOGG_TOTALCMD_ROOT%\ /y
+xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\msvcp140_1.dll" %KLOGG_TOTALCMD_ROOT%\ /y
+xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\msvcp140_2.dll" %KLOGG_TOTALCMD_ROOT%\ /y
+xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\vcruntime140.dll" %KLOGG_TOTALCMD_ROOT%\ /y
+xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\vcruntime140_1.dll" %KLOGG_TOTALCMD_ROOT%\ /y
+
+xcopy %SSL_DIR%\libcrypto-1_1%SSL_ARCH%.dll %KLOGG_TOTALCMD_ROOT%\ /y
+xcopy %SSL_DIR%\libssl-1_1%SSL_ARCH%.dll %KLOGG_TOTALCMD_ROOT%\ /y
+
 xcopy %QTDIR%\bin\%KLOGG_QT%Core.dll %KLOGG_TOTALCMD_ROOT%\ /y
 xcopy %QTDIR%\bin\%KLOGG_QT%Gui.dll %KLOGG_TOTALCMD_ROOT%\ /y
 xcopy %QTDIR%\bin\%KLOGG_QT%Network.dll %KLOGG_TOTALCMD_ROOT%\ /y
@@ -84,6 +93,10 @@ xcopy %QTDIR%\bin\%KLOGG_QT%Widgets.dll %KLOGG_TOTALCMD_ROOT%\ /y
 xcopy %QTDIR%\bin\%KLOGG_QT%Concurrent.dll %KLOGG_TOTALCMD_ROOT%\ /y
 xcopy %QTDIR%\bin\%KLOGG_QT%Xml.dll %KLOGG_TOTALCMD_ROOT%\ /y
 xcopy %QTDIR%\bin\%KLOGG_QT%Core5Compat.dll %KLOGG_TOTALCMD_ROOT%\ /y
+
+if exist %KLOGG_WORKSPACE%\release\tbb12.dll (
+    xcopy %KLOGG_WORKSPACE%\release\tbb12.dll %KLOGG_TOTALCMD_ROOT%\ /y >nul
+)
 
 xcopy %QTDIR%\plugins\platforms\qwindows.dll %KLOGG_TOTALCMD_ROOT%\platforms\ /y
 if exist %QTDIR%\plugins\styles\qwindowsvistastyle.dll (


### PR DESCRIPTION
## Summary
- copy the MSVC, OpenSSL, and tbb runtime DLLs into the staged Total Commander plugin bundle
- document that the packaging step now brings the additional runtimes alongside the Qt modules

## Testing
- not run (windows packaging script)

------
https://chatgpt.com/codex/tasks/task_e_68d9bc08b93883228f060d77e1620d66