### PR TITLE
Sanitize manifest values before writing

### DIFF
--- a/packaging/windows/write_plugin_manifest.ps1
+++ b/packaging/windows/write_plugin_manifest.ps1
@@ -41,9 +41,15 @@ if (-not $Version) {
     $Version = '0.0.0'
 }
 
-$PluginFile = $PluginFile.Trim()
-$PluginType = $PluginType.Trim()
-$Version = $Version.Trim()
+$sanitize = {
+    param([string]$value)
+    if ($null -eq $value) { return '' }
+    return $value.Trim().Replace("`r", '').Replace("`n", '')
+}
+
+$PluginFile = & $sanitize $PluginFile
+$PluginType = & $sanitize $PluginType
+$Version = & $sanitize $Version
 
 $manifestPath = Join-Path $PluginRoot 'pluginst.inf'
 
@@ -58,4 +64,9 @@ $lines = @(
     'defaultextension=LOG LOGX LOGS CEF CLF ELF W3C OUT ERR'
 )
 
-Set-Content -Path $manifestPath -Value $lines -Encoding Ascii -Force
+$content = ($lines -join "`n") + "`n"
+[System.IO.File]::WriteAllText(
+    $manifestPath,
+    $content,
+    [System.Text.Encoding]::ASCII
+)


### PR DESCRIPTION
## Summary
- add a helper that trims manifest values and removes embedded carriage return or line-feed characters
- reuse the helper for the plugin file name, plugin type, and version prior to writing the manifest

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9bbbb128883228eb376f8faa8f513