### PR TITLE
Template Total Commander manifest

### DIFF
--- a/packaging/windows/pluginst.inf
+++ b/packaging/windows/pluginst.inf
@@ -1,0 +1,8 @@
+[plugininstall]
+version=0.0.0
+defaultdir=klogg_lister
+type=wlx64
+file=klogg_lister.wlx64
+name=Klogg Log Viewer
+description=Log viewer plugin for Total Commander
+defaultextension=LOG LOGX LOGS CEF CLF ELF W3C OUT ERR

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -102,11 +102,9 @@ xcopy %KLOGG_WORKSPACE%\COPYING %KLOGG_TOTALCMD_ROOT%\ /y
 xcopy %KLOGG_WORKSPACE%\NOTICE %KLOGG_TOTALCMD_ROOT%\ /y
 
 echo "Writing Total Commander auto-install manifest..."
-for %%F in ("%KLOGG_TOTALCMD_ROOT%\pluginst.inf") do del "%%~fF" 2>nul
+copy /y "%KLOGG_WORKSPACE%\packaging\windows\pluginst.inf" "%KLOGG_TOTALCMD_ROOT%\pluginst.inf" >nul
 powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%KLOGG_WORKSPACE%\packaging\windows\write_plugin_manifest.ps1" ^
   -PluginRoot "%KLOGG_TOTALCMD_ROOT%" ^
-  -PluginFile "%KLOGG_TOTALCMD_PLUGIN_FILE%" ^
-  -PluginType "%KLOGG_TOTALCMD_PLUGIN_TYPE%" ^
   -Version "%KLOGG_VERSION%"
 
 md %KLOGG_WORKSPACE%\release\platforms

--- a/packaging/windows/write_plugin_manifest.ps1
+++ b/packaging/windows/write_plugin_manifest.ps1
@@ -4,13 +4,7 @@ param(
     [string]$PluginRoot = $(if ($env:KLOGG_WORKSPACE) { Join-Path $env:KLOGG_WORKSPACE 'release/totalcmd' } else { '' }),
 
     [Parameter()]
-    [string]$Version = $env:KLOGG_VERSION,
-
-    [Parameter()]
-    [string]$PluginFile,
-
-    [Parameter()]
-    [string]$PluginType
+    [string]$Version = $env:KLOGG_VERSION
 )
 
 Set-StrictMode -Version Latest
@@ -23,39 +17,49 @@ if (-not (Test-Path -LiteralPath $PluginRoot)) {
     throw "Plugin root '$PluginRoot' does not exist."
 }
 
-$arch = $env:KLOGG_ARCH
-$defaultIs64 = $false
-if ($arch -and ($arch -match '64')) {
-    $defaultIs64 = $true
-}
-
-if (-not $PluginFile) {
-    $PluginFile = if ($defaultIs64) { 'klogg_lister.wlx64' } else { 'klogg_lister.wlx' }
-}
-
-if (-not $PluginType) {
-    $PluginType = if ($defaultIs64) { 'wlx64' } else { 'wlx' }
-}
-
 if (-not $Version) {
     $Version = '0.0.0'
 }
 
-$PluginFile = $PluginFile.Trim()
-$PluginType = $PluginType.Trim()
-$Version = $Version.Trim()
+$sanitize = {
+    param([string]$value)
+    if ($null -eq $value) { return '' }
+    return $value.Trim().Replace("`r", '').Replace("`n", '')
+}
+
+$Version = & $sanitize $Version
+if (-not $Version) {
+    $Version = '0.0.0'
+}
 
 $manifestPath = Join-Path $PluginRoot 'pluginst.inf'
+if (-not (Test-Path -LiteralPath $manifestPath)) {
+    throw "Manifest file '$manifestPath' does not exist."
+}
 
-$lines = @(
-    '[plugininstall]',
-    'version=' + $Version,
-    'defaultdir=klogg_lister',
-    'type=' + $PluginType,
-    'file=' + $PluginFile,
-    'name=Klogg Log Viewer',
-    'description=Log viewer plugin for Total Commander',
-    'defaultextension=LOG LOGX LOGS CEF CLF ELF W3C OUT ERR'
+$content = [System.IO.File]::ReadAllText($manifestPath, [System.Text.Encoding]::ASCII)
+if (-not $content) {
+    $content = ''
+}
+
+$pattern = '^(version=).*$'
+if (-not [System.Text.RegularExpressions.Regex]::IsMatch($content, $pattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)) {
+    throw "Manifest file '$manifestPath' is missing a version entry."
+}
+
+$newContent = [System.Text.RegularExpressions.Regex]::Replace(
+    $content,
+    $pattern,
+    "`$1$Version",
+    [System.Text.RegularExpressions.RegexOptions]::Multiline
 )
 
-Set-Content -Path $manifestPath -Value $lines -Encoding Ascii -Force
+if (-not $newContent.EndsWith("`n")) {
+    $newContent += "`n"
+}
+
+[System.IO.File]::WriteAllText(
+    $manifestPath,
+    $newContent,
+    [System.Text.Encoding]::ASCII
+)


### PR DESCRIPTION
## Summary
- check in a canonical Total Commander `pluginst.inf` template with LF-only newlines
- copy the template into the release tree before updating it during packaging
- change the manifest writer script to only sanitize and update the version field in the existing manifest

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9bbbb128883228eb376f8faa8f513