### PR TITLE
Handle missing manifest entries when updating metadata

### DIFF
--- a/packaging/windows/write_plugin_manifest.ps1
+++ b/packaging/windows/write_plugin_manifest.ps1
@@ -4,7 +4,13 @@ param(
     [string]$PluginRoot = $(if ($env:KLOGG_WORKSPACE) { Join-Path $env:KLOGG_WORKSPACE 'release/totalcmd' } else { '' }),
 
     [Parameter()]
-    [string]$Version = $env:KLOGG_VERSION
+    [string]$Version = $env:KLOGG_VERSION,
+
+    [Parameter()]
+    [string]$PluginFile,
+
+    [Parameter()]
+    [string]$PluginType
 )
 
 Set-StrictMode -Version Latest
@@ -32,6 +38,9 @@ if (-not $Version) {
     $Version = '0.0.0'
 }
 
+$PluginFile = & $sanitize $PluginFile
+$PluginType = & $sanitize $PluginType
+
 $manifestPath = Join-Path $PluginRoot 'pluginst.inf'
 if (-not (Test-Path -LiteralPath $manifestPath)) {
     throw "Manifest file '$manifestPath' does not exist."
@@ -42,17 +51,44 @@ if (-not $content) {
     $content = ''
 }
 
-$pattern = '^(version=).*$'
-if (-not [System.Text.RegularExpressions.Regex]::IsMatch($content, $pattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)) {
-    throw "Manifest file '$manifestPath' is missing a version entry."
+$options = [System.Text.RegularExpressions.RegexOptions]::Multiline
+
+function Set-ManifestEntry {
+    param(
+        [string]$currentContent,
+        [string]$entryName,
+        [string]$entryValue
+    )
+
+    $pattern = "^(" + [System.Text.RegularExpressions.Regex]::Escape($entryName) + "=).*$"
+    $updated = [System.Text.RegularExpressions.Regex]::Replace(
+        $currentContent,
+        $pattern,
+        "`$1$entryValue",
+        $options
+    )
+
+    if ($updated -ne $currentContent) {
+        return $updated
+    }
+
+    $suffixNewLine = ''
+    if ($currentContent -and -not $currentContent.EndsWith("`n")) {
+        $suffixNewLine = "`n"
+    }
+
+    return $currentContent + $suffixNewLine + "$entryName=$entryValue`n"
 }
 
-$newContent = [System.Text.RegularExpressions.Regex]::Replace(
-    $content,
-    $pattern,
-    "`$1$Version",
-    [System.Text.RegularExpressions.RegexOptions]::Multiline
-)
+$newContent = Set-ManifestEntry -currentContent $content -entryName 'version' -entryValue $Version
+
+if ($PluginFile) {
+    $newContent = Set-ManifestEntry -currentContent $newContent -entryName 'file' -entryValue $PluginFile
+}
+
+if ($PluginType) {
+    $newContent = Set-ManifestEntry -currentContent $newContent -entryName 'type' -entryValue $PluginType
+}
 
 if (-not $newContent.EndsWith("`n")) {
     $newContent += "`n"


### PR DESCRIPTION
## Summary
- replace strict entry validation with a helper that updates or appends manifest values
- ensure version, file, and type entries are created when missing instead of throwing

## Testing
- not run (script change only)

------
https://chatgpt.com/codex/tasks/task_e_68d9f1a355948322bf4046164881ddfd