### PR TITLE
Fix plugin manifest script to avoid undefined ensureEntry

### DIFF
--- a/packaging/windows/write_plugin_manifest.ps1
+++ b/packaging/windows/write_plugin_manifest.ps1
@@ -90,28 +90,6 @@ if ($PluginType) {
     $newContent = Set-ManifestEntry -currentContent $newContent -entryName 'type' -entryValue $PluginType
 }
 
-if ($PluginFile) {
-    $filePattern = '^(file=).*$'
-    & $ensureEntry $filePattern 'file'
-    $newContent = [System.Text.RegularExpressions.Regex]::Replace(
-        $newContent,
-        $filePattern,
-        "`$1$PluginFile",
-        $options
-    )
-}
-
-if ($PluginType) {
-    $typePattern = '^(type=).*$'
-    & $ensureEntry $typePattern 'type'
-    $newContent = [System.Text.RegularExpressions.Regex]::Replace(
-        $newContent,
-        $typePattern,
-        "`$1$PluginType",
-        $options
-    )
-}
-
 if (-not $newContent.EndsWith("`n")) {
     $newContent += "`n"
 }


### PR DESCRIPTION
## Summary
- remove the redundant ensureEntry invocation in write_plugin_manifest.ps1 that referenced an undefined variable
- rely on Set-ManifestEntry to add or update entries, preventing the release workflow from failing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0a68f50c83229e56b30301524d01