### PR TITLE
Fix MSVC build errors in lister plugin initialization

### DIFF
--- a/src/plugins/total_commander_lister/src/lister_plugin.cpp
+++ b/src/plugins/total_commander_lister/src/lister_plugin.cpp
@@ -49,6 +49,8 @@ QFile& logFile()
     return file;
 }
 
+void writeLogLine( const QString& category, const QString& message );
+
 const QStringList& supportedExtensions()
 {
     static const QStringList extensions = { QStringLiteral( "LOG" ),  QStringLiteral( "LOGX" ),
@@ -90,7 +92,8 @@ int populateDetectString( char* buffer, int maxLength )
 
     const QByteArray asciiDetect = detectString().toUtf8();
     const int available = maxLength - 1;
-    const int copyLength = std::min( available, asciiDetect.size() );
+    const int copyLength = static_cast<int>( std::min<qsizetype>(
+        static_cast<qsizetype>( available ), asciiDetect.size() ) );
 
     if ( copyLength > 0 ) {
         std::memcpy( buffer, asciiDetect.constData(), static_cast<size_t>( copyLength ) );


### PR DESCRIPTION
## Summary
- declare the logging helper before populateDetectString so MSVC can resolve it
- compute the copy length using consistent types to satisfy std::min on MSVC

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe33b14848322a5bf2fbe7fd81687