### PR TITLE
Fix logging dependency for Total Commander lister plugin

### DIFF
--- a/src/plugins/total_commander_lister/CMakeLists.txt
+++ b/src/plugins/total_commander_lister/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(klogg_lister_plugin
     PRIVATE
         project_options
         project_warnings
+        klogg_logging
         klogg_ui
         klogg_settings
         Qt${QT_VERSION_MAJOR}::Widgets

--- a/src/plugins/total_commander_lister/src/lister_plugin.cpp
+++ b/src/plugins/total_commander_lister/src/lister_plugin.cpp
@@ -27,7 +27,7 @@
 #include "configuration.h"
 #include "lister_plugin_api.h"
 #include "lister_viewer_widget.h"
-#include "logging/include/logger.h"
+#include "logger.h"
 #include "persistentinfo.h"
 
 namespace klogg::tc::lister {


### PR DESCRIPTION
## Summary
- include the shared logging header in the lister plugin using the exported path
- link the lister plugin against the klogg_logging target so the header and symbols are available

## Testing
- not run (Windows-only build configuration)


------
https://chatgpt.com/codex/tasks/task_e_68dc97efd8548322a7286d1556501a20