### PR TITLE
Initialize HighlighterSetCollection in Total Commander plugin

### DIFF
--- a/src/plugins/total_commander_lister/src/lister_plugin.cpp
+++ b/src/plugins/total_commander_lister/src/lister_plugin.cpp
@@ -29,6 +29,7 @@
 #include "lister_viewer_widget.h"
 #include "logger.h"
 #include "persistentinfo.h"
+#include "highlighterset.h"
 
 namespace klogg::tc::lister {
 
@@ -520,6 +521,7 @@ bool ensureQtApplication( QString* failureReason = nullptr )
                                                  QStringLiteral( "klogg_lister_session" ) );
         PersistentInfo::overridePortableMode( true );
         Configuration::getSynced();
+        HighlighterSetCollection::getSynced();
         writeLogLine( QStringLiteral( "plugin" ), QStringLiteral( "settings initialized" ) );
     }
 


### PR DESCRIPTION
## Summary
- load the highlighter set collection during Total Commander lister plugin startup to avoid uninitialized access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dca3a9fb5c8322b4a9b7baaed7a790