### PR TITLE
Adjust visible column calculation to viewport contents

### DIFF
--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1773,11 +1773,14 @@ int AbstractLogView::calculateLeftMarginPx() const
 // Returns the number of columns visible in the viewport
 LineLength AbstractLogView::getNbVisibleCols() const
 {
-    const auto scrollBarWidth = verticalScrollBar()->isVisible() ? verticalScrollBar()->width() : 0;
+    const auto viewportRect = viewport()->contentsRect();
     const auto leftMargin = calculateLeftMarginPx();
     const auto charWidth = std::max( charWidth_, 1 );
-    const auto availableWidth = std::max( viewport()->width() - leftMargin - scrollBarWidth, 0 );
-    return LineLength{ availableWidth / charWidth + 1 };
+    const auto contentRight = viewportRect.right() - ContentMarginWidth;
+    const auto availableWidth
+        = std::max( contentRight - leftMargin + 1, 0 );
+    const auto visibleColumns = ( availableWidth + charWidth - 1 ) / charWidth;
+    return LineLength{ std::max( visibleColumns, 0 ) };
 }
 
 // Converts the mouse x, y coordinates to the line number in the file


### PR DESCRIPTION
## Summary
- base the visible column count on the viewport contents rect instead of the full widget width
- round the available width up to the next whole character so long lines fill the visible area without leaving a gap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd4817c3488322aa81895568cb6a12